### PR TITLE
Change project order to match cards on openclarity.io

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,7 @@
 
 # [OpenClarity](https://openclarity.io)
 
-OpenClarity is a suite of open source tools for cloud native security and observability — VMClarity, APIClarity, and KubeClarity. Read more about each project below.
+OpenClarity is a suite of open source tools for cloud native security and observability — VMClarity, KubeClarity, and APIClarity. Read more about each project below.
 
 ## [VMClarity](https://github.com/openclarity/vmclarity)
 
@@ -19,6 +19,18 @@ Key Capabilities:
 - Misconfiguration detection
 - Rootkit detection
 
+## [KubeClarity](https://github.com/openclarity/kubeclarity)
+
+KubeClarity is a tool for detection and management of software bills of materials (SBOMs) and vulnerabilities in container images and filesystems. It scans both runtime Kubernetes clusters and CI/CD pipelines for enhanced software supply-chain security.
+
+![kube-clarity-diagram](profile/img/kube-clarity-diagram.webp)
+
+Key Capabilities:
+
+- SBOM and vulnerability detection
+- Comprehensive dashboard for SBOM analysis
+- Pluggable architecture
+
 ## [APIClarity](https://github.com/openclarity/apiclarity)
 
 APIClarity is an open source tool for APIs that helps you visualize and identify potential risks around API usage in your cloud native environments. It helps build the OpenAPI specifications for all APIs in your environment, then helps track drift, shadow or zombie usage for those APIs. You can then use this information to build your application security posture.
@@ -30,15 +42,3 @@ Key Capabilities:
 - Quick and easy API visibility and analysis
 - Comprehensive dashboard to monitor APIs
 - Designed for developers, loved by security teams
-
-## [KubeClarity](https://github.com/openclarity/kubeclarity)
-
-KubeClarity is a tool for detection and management of software bills of materials (SBOMs) and vulnerabilities in container images and filesystems. It scans both runtime Kubernetes clusters and CI/CD pipelines for enhanced software supply-chain security.
-
-![kube-clarity-diagram](profile/img/kube-clarity-diagram.webp)
-
-Key Capabilities
-
-- SBOM and vulnerability detection
-- Comprehensive dashboard for SBOM analysis
-- Pluggable architecture


### PR DESCRIPTION
Using these project cards from https://openclarity.io as our reference, we should standardize our project ordering across both GitHub profile and OpenClarity website text to match:

<img width="1162" alt="Screen Shot 2023-04-20 at 4 41 02 PM" src="https://user-images.githubusercontent.com/2418071/233482945-71521c7f-3814-4199-b350-31c41bfb87d4.png">
