### PR TITLE
Decrease org-wide default for stalebot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -37,7 +37,8 @@ markComment: >
 
 # Comment to post when closing a stale Issue or Pull Request.
 # closeComment: >
-#   Your comment here.
+  This stale issue is now closed due to inactivity. Please re-open or re-file if
+  if the issue is still relevant. Thank you!
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -27,9 +27,9 @@ staleLabel: stale
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  Thank you for your contribution! Since there hasn't been any recent activity,
+  this issue has been automatically marked as stale, and may eventually be closed.
+  Please bump this issue or contact the maintainer(s) if you want to keep it open.
 
 # Comment to post when removing the stale label.
 # unmarkComment: >

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,11 +1,11 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 100
+daysUntilStale: 30
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 20
+daysUntilClose: 15
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 onlyLabels: []

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -29,7 +29,7 @@ staleLabel: stale
 markComment: >
   Thank you for your contribution! Since there hasn't been any recent activity,
   this issue has been automatically marked as stale, and may eventually be closed.
-  Please bump this issue or contact the maintainer(s) if you want to keep it open.
+  Please bump this issue by leaving a comment if you want to keep it open.
 
 # Comment to post when removing the stale label.
 # unmarkComment: >


### PR DESCRIPTION
As discussed, let's dial the org-wide StaleBot defaults down, and allow individual projects to override these settings at the repository level, should they need them to be less (or more) aggressive.