### PR TITLE
Reusable stale issue workflow

### DIFF
--- a/.github/workflows/_stale.yml
+++ b/.github/workflows/_stale.yml
@@ -1,4 +1,4 @@
-name: stale
+name: _stale
 
 on:
   workflow_call:

--- a/.github/workflows/stale-check.yml
+++ b/.github/workflows/stale-check.yml
@@ -1,0 +1,18 @@
+name: stale-check
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+jobs:
+  mark-stale:
+    uses: ./.github/workflows/_stale.yml
+    permissions:
+      issues: write
+      pull-requests: write
+    with:
+      days-until-stale: 60
+      days-until-close: 20
+      stale-label: "stale"
+      exempt-label: "keep"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,43 +1,58 @@
 name: stale
 
 on:
-  schedule:
-    - cron: "0 0 * * 0"
+  workflow_call:
+    inputs:
+      days-until-stale:
+        type: number
+        required: false
+        default: 15
+      days-until-close:
+        type: number
+        required: false
+        default: 30
+      stale-label:
+        type: string
+        required: false
+        default: "stale"
+      exempt-label:
+        type: string
+        required: false
+        default: "keep"
 
 jobs:
   stale:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
     steps:
       - name: 📆 mark stale activity
         uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 30
-          days-before-close: 15
-          stale-issue-label: "stale"
-          stale-pr-label: "stale"
-          exempt-issue-labels: "keep"
-          exempt-pr-labels: "keep"
+          days-before-stale: ${{ inputs.days-until-stale }}
+          days-before-close: ${{ inputs.days-until-close }}
+          stale-issue-label: ${{ inputs.stale-label }}
+          stale-pr-label: ${{ inputs.stale-label }}
+          exempt-issue-labels: ${{ inputs.exempt-label }}
+          exempt-pr-labels: ${{ inputs.exempt-label }}
           stale-issue-message: >
             Thank you for your contribution! This issue has been automatically
-            marked as 'stale' because it has no recent activity in the last 30
-            days. It will be closed in 15 days, if no further activity occurs.
-            If this issue is still relevant, please leave a comment to let us
-            know, and the 'stale' label will be automatically removed.
+            marked as `stale` because it has no recent activity in the last
+            ${{ inputs.days-until-stale }} days. It will be closed in
+            ${{ inputs.days-until-close }} days, if no further activity
+            occurs. If this issue is still relevant, please leave a comment to
+            let us know, and the `stale` label will be automatically removed.
           stale-pr-message: >
             Thank you for your contribution! This PR has been automatically
-            marked as 'stale' because it has no recent activity in the last 30
-            days. It will be closed in 15 days, if no further activity occurs.
+            marked as `stale` because it has no recent activity in the last
+            ${{ inputs.days-until-stale }} days. It will be closed in
+            ${{ inputs.days-until-close }} days, if no further activity occurs.
             If this pull request is still relevant, please leave a comment to 
-            let us know, and the 'stale' label will be automatically removed.
+            let us know, and the `stale` label will be automatically removed.
           close-issue-message: >
-            This issue has been marked 'stale' for 15 days, and is now closed
-            due to inactivity. If the issue is still relevant, please re-open
-            this issue or file a new one. Thank you!
+            This issue has been marked `stale` for ${{ inputs.days-until-close }}
+            days, and is now closed due to inactivity. If the issue is still
+            relevant, please re-open this issue or file a new one. Thank you!
           close-pr-message: >
-            This pull request has been marked 'stale' for 15 days, and is now 
-            closed due to inactivity. If this contribution is still relevant,
-            please re-open this PR or file a new one. Thank you!
+            This PR has been marked `stale` for ${{ inputs.days-until-close }}
+            days, and is now closed due to inactivity. If this contribution is
+            still relevant, please re-open this PR or file a new one. Thank you!


### PR DESCRIPTION
## Description

- Migrates `stale.yml` workflow into [reusable](https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow) `_stale.yml` base workflow (pinned to `@main`)
- Ports core functionality from existing workflow, while adding inputs to maximize flexibility
- Allows project maintainers to override default inputs (custom labels, stale intervals) and define custom workflow triggers (cron schedule, manual dispatch)
- Maintainers can either pin the workflow to the `main` branch to always receive the latest workflow updates, or freeze to a specific commit hash for extra stability
- See https://github.com/openclarity/kubeclarity/pull/469 for companion PR which demonstrates how workflow inheritance can be adopted by other `openclarity` projects

## Type of Change

[ ] Bug Fix
[ ] New Feature
[ ] Breaking Change
[x] Refactor
[ ] Documentation
[ ] Other (please describe)