### PR TITLE
Add missing org member fekete-robert

### DIFF
--- a/org/openclarity/org.yaml
+++ b/org/openclarity/org.yaml
@@ -39,6 +39,7 @@ members:
   - dneduva-cisco
   - embonshai
   - eti-tme-tim
+  - fekete-robert
   - fluffy
   - gicont
   - jadiaconu


### PR DESCRIPTION
Fixes #20 which failed dry-run due to fekete-robert not already being a member of the openclarity org.