### PR TITLE
chore: add users to kubeclarity teams

### DIFF
--- a/org/openclarity/kubeclarity/teams.yaml
+++ b/org/openclarity/kubeclarity/teams.yaml
@@ -7,6 +7,9 @@ teams:
       - FrimIdan
       - justaugustus
       - Tehsmash
+    members:
+      - chrisgacsal
+      - ramizpolic
     privacy: closed
     repos:
       kubeclarity: admin
@@ -20,9 +23,11 @@ teams:
       - Tehsmash
     members:
       - abaklor
+      - chrisgacsal
       - lgecse
       - pbalogh-sa
       - pkalapat
+      - ramizpolic
     privacy: closed
     repos:
       kubeclarity: maintain


### PR DESCRIPTION
Add the following user to `kubeclarity-admins` and `kubeclarity-maintainers` teams:

* `chrisgacsal`
* `ramizpolic`