### PR TITLE
fix: openclarity project diagrams

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -21,7 +21,7 @@ OpenClarity delivers:
 
 [VMClarity](https://github.com/openclarity/vmclarity) is a tool for agentless detection and management of virtual machine Software Bill Of Materials (SBOM) and security threats such as vulnerabilities, exploits, malware, rootkits, misconfigurations, and leaked secrets.
 
-![vm-clarity-diagram](profile/img/vm-clarity-diagram.webp)
+![vm-clarity-diagram](img/vm-clarity-diagram.webp)
 
 Key Capabilities:
 
@@ -37,7 +37,7 @@ Key Capabilities:
 
 [KubeClarity](https://github.com/openclarity/kubeclarity) is a tool for detection and management of software bills of materials (SBOMs) and vulnerabilities in container images and filesystems. It scans both runtime Kubernetes clusters and CI/CD pipelines for enhanced software supply-chain security.
 
-![kube-clarity-diagram](profile/img/kube-clarity-diagram.webp)
+![kube-clarity-diagram](img/kube-clarity-diagram.webp)
 
 Key Capabilities:
 
@@ -49,7 +49,7 @@ Key Capabilities:
 
 [APIClarity](https://github.com/openclarity/apiclarity) is a tool that helps you visualize and identify potential risks around API usage in your cloud native environments. It helps build the OpenAPI specifications for all APIs in your environment, then helps track drift, shadow or zombie usage for those APIs. You can then use this information to build your application security posture.
 
-![api-clarity-diagram](profile/img/apiclarity-docs-diagram.jpeg)
+![api-clarity-diagram](img/apiclarity-docs-diagram.jpeg)
 
 Key Capabilities:
 


### PR DESCRIPTION
Project diagrams were not showing on org homepage